### PR TITLE
chore: use standard library to unmarshal json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/gamussa/testcontainers-go-kong
 go 1.17
 
 require (
-	github.com/spyzhov/ajson v0.7.1
 	github.com/stretchr/testify v1.8.0
 	github.com/testcontainers/testcontainers-go v0.13.1-0.20220829163733-097f9af0d0b7
 )

--- a/go.sum
+++ b/go.sum
@@ -815,8 +815,6 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
-github.com/spyzhov/ajson v0.7.1 h1:1MDIlPc6x0zjNtpa7tDzRAyFAvRX+X8ZsvtYz5lZg6A=
-github.com/spyzhov/ajson v0.7.1/go.mod h1:63V+CGM6f1Bu/p4nLIN8885ojBdt88TbLoSFzyqMuVA=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/kong_test.go
+++ b/kong_test.go
@@ -124,5 +124,5 @@ func TestKongAdminAPI_ReturnVersion(t *testing.T) {
 	value := res.Headers.Host
 	assert.True(t, strings.Contains(value, "mockbin"))
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "Expected status code %d. Got %d.", http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "kong/2.8.1", resp.Header.Get("Server"), "Expected version %s. Got %s.", "2.6", resp.Header.Get("Server"))
+	assert.Equal(t, "kong/2.8.1", resp.Header.Get("Server"), "Expected version %s. Got %s.", "2.8.1", resp.Header.Get("Server"))
 }


### PR DESCRIPTION
## What does this PR do?
It uses Go's standard library to unmarshal the JSON response, generating a representation of the entire JSON response as a struct.

I generated the struct on-the-fly from here:https://mholt.github.io/json-to-go/

You can super-simplify it just removing the fields that you are not interested in (here we are only creating assertions for the Headers.Host fields)

### Commits
- chore: use standard library for json unmarshal
- chore: run go mod tidy
- fix: proper error message in assertion

