### PR TITLE
feat: build the plugin and copy to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,4 @@
-FROM golang:1.18-bullseye as builder
-
-WORKDIR $GOPATH/src/kong/
-
-COPY . .
-
-RUN go mod download
-RUN go mod verify
-
-# Compile the goplug plugin
-RUN GOOS=linux GOARCH=amd64 go build -o go-plugins/bin/goplug go-plugins/goplug.go
-
 ARG TC_KONG_IMAGE
 FROM ${TC_KONG_IMAGE:-kong:2.8.1}
 
-COPY --from=builder /go/src/kong/go-plugins/bin /usr/local/kong/go-plugins/bin
+RUN mkdir -p /usr/local/kong/go-plugins/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+ARG TC_KONG_IMAGE
+FROM ${TC_KONG_IMAGE:-kong:2.8.1}
+
+RUN mkdir -p /usr/local/kong/go-plugins/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,16 @@
+FROM golang:1.18-bullseye as builder
+
+WORKDIR $GOPATH/src/kong/
+
+COPY . .
+
+RUN go mod download
+RUN go mod verify
+
+# Compile the goplug plugin
+RUN GOOS=linux GOARCH=amd64 go build -o go-plugins/bin/goplug go-plugins/goplug.go
+
 ARG TC_KONG_IMAGE
 FROM ${TC_KONG_IMAGE:-kong:2.8.1}
 
-RUN mkdir -p /usr/local/kong/go-plugins/bin
+COPY --from=builder /go/src/kong/go-plugins/bin /usr/local/kong/go-plugins/bin

--- a/go-plugins/Makefile
+++ b/go-plugins/Makefile
@@ -1,3 +1,0 @@
-.PHONY: build-plugin 
-build-plugin:
-	GOOS='linux' GOARCH='amd64' go build -o bin/goplug goplug.go

--- a/go-plugins/Makefile
+++ b/go-plugins/Makefile
@@ -1,0 +1,3 @@
+.PHONY: build-plugin 
+build-plugin:
+	GOOS='linux' GOARCH='amd64' go build -o bin/goplug goplug.go

--- a/go-plugins/goplug.go
+++ b/go-plugins/goplug.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"log"
+	"strings"
+
+	"github.com/Kong/go-pdk"
+	"github.com/Kong/go-pdk/server"
+)
+
+type Config struct {
+	Attach bool
+}
+
+func New() interface{} {
+	return &Config{}
+}
+
+const Version string = "0.0.1"
+const Priority = 1
+
+func main() {
+	server.StartServer(New, Version, Priority)
+}
+
+func (c Config) Access(kong *pdk.PDK) {
+	userAgent, _ := kong.Request.GetHeader("user-agent")
+	log.Printf("Got request from %s", userAgent)
+
+	if c.Attach {
+		if strings.Contains(userAgent, "Kong Builders") {
+			kong.Response.SetHeader("X-Kong-Builders", "Welcome to the jungle 🌴")
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gamussa/testcontainers-go-kong
 go 1.17
 
 require (
+	github.com/Kong/go-pdk v0.8.0
 	github.com/stretchr/testify v1.8.0
 	github.com/testcontainers/testcontainers-go v0.13.1-0.20220829163733-097f9af0d0b7
 )
@@ -34,6 +35,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/ugorji/go/codec v1.2.7 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/net v0.0.0-20220617184016-355a448f1bc9 // indirect
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Kong/go-pdk v0.8.0 h1:5HvFuADux2KUOxoEEESie0s1wlFJdNzTl3IQ+UKokyo=
+github.com/Kong/go-pdk v0.8.0/go.mod h1:D6tpamZZ1hZp3PEksGCbvlS+g0J2RhGTw7eZW3D7v5I=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
@@ -844,6 +846,12 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/ugorji/go v1.2.1/go.mod h1:cSVypSfTLm2o9fKxXvQgn3rMmkPXovcWor6Qn5tbFmI=
+github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=
+github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6M=
+github.com/ugorji/go/codec v1.2.1/go.mod h1:s/WxCRi46t8rA+fowL40EnmD7ec0XhR7ZypxeBNdzsM=
+github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
+github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=

--- a/kong.go
+++ b/kong.go
@@ -24,6 +24,7 @@ func SetupKong(ctx context.Context, image string, environment map[string]string)
 			BuildArgs: map[string]*string{
 				"TC_KONG_IMAGE": &image,
 			},
+			PrintBuildLog: true,
 		},
 		ExposedPorts: []string{"8001/tcp", "8000/tcp"},
 		WaitingFor:   wait.ForListeningPort("8001/tcp"),
@@ -35,6 +36,11 @@ func SetupKong(ctx context.Context, image string, environment map[string]string)
 				HostFilePath:      "./kong.yaml",
 				ContainerFilePath: "/usr/local/kong/kong.yaml",
 				FileMode:          0644, // see https://github.com/supabase/cli/pull/132/files
+			},
+			{
+				HostFilePath:      "./go-plugins/bin/goplug", // copy the already compiled binary to the
+				ContainerFilePath: "/usr/local/kong/go-plugins/bin/goplug",
+				FileMode:          0755,
 			},
 		},
 	}

--- a/kong.go
+++ b/kong.go
@@ -36,11 +36,6 @@ func SetupKong(ctx context.Context, image string, environment map[string]string)
 				ContainerFilePath: "/usr/local/kong/kong.yaml",
 				FileMode:          0644, // see https://github.com/supabase/cli/pull/132/files
 			},
-			{
-				HostFilePath:      "./go-plugins/bin/goplug", // copy the already compiled binary to the
-				ContainerFilePath: "/usr/local/kong/go-plugins/bin/goplug",
-				FileMode:          0755,
-			},
 		},
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{

--- a/kong.go
+++ b/kong.go
@@ -38,7 +38,7 @@ func SetupKong(ctx context.Context, image string, environment map[string]string)
 				FileMode:          0644, // see https://github.com/supabase/cli/pull/132/files
 			},
 			{
-				HostFilePath:      "./go-plugins/bin/goplug", // copy the already compiled binary to the
+				HostFilePath:      "./go-plugins/bin/goplug", // copy the already compiled binary to the plugins dir
 				ContainerFilePath: "/usr/local/kong/go-plugins/bin/goplug",
 				FileMode:          0755,
 			},

--- a/kong.yaml
+++ b/kong.yaml
@@ -5,3 +5,7 @@ services:
     routes:
       - paths:
           - '/'
+    plugins:
+      - name: goplug
+        config:
+          attach: true

--- a/kong_test.go
+++ b/kong_test.go
@@ -47,6 +47,11 @@ func TestKongAdminAPI_ReturnVersion(t *testing.T) {
 		"KONG_ADMIN_ERROR_LOG":    "/dev/stderr",
 		"KONG_ADMIN_LISTEN":       "0.0.0.0:8001",
 		"KONG_DECLARATIVE_CONFIG": "/usr/local/kong/kong.yaml",
+		//------------ Kong Plugins -----------------
+		"KONG_PLUGINS":                       "goplug",
+		"KONG_PLUGINSERVER_NAMES":            "goplug",
+		"KONG_PLUGINSERVER_GOPLUG_START_CMD": "/usr/local/kong/go-plugins/bin/goplug",
+		"KONG_PLUGINSERVER_GOPLUG_QUERY_CMD": "/usr/local/kong/go-plugins/bin/goplug -dump",
 	}
 
 	kong, err := SetupKong(ctx, "kong:2.8.1", env)


### PR DESCRIPTION
## What does this PR do?
It builds the goplug.go plugin using a Makefile. The resulting artifact will be copied to the container before it's in the running state.

The Docker image for kong is built using the BuildFromDockerfile API in tc-go, passing a BUILD_ARG with the base image. Finally we simply copy the already built plugin to the right directory.

## Why is it important?
There are two main concerns:

1. at this moment, tc-go does not support copying directories to containers. But it could be done in the short term: https://github.com/testcontainers/testcontainers-go/issues/516
2. I realised I could not simply copy the binary to the `go-plugins/bin` dir in the kong image because it did not have that directory created, therefore we are forced to create it. I thought about implementing the copyDir feature in tc-go, but as a workaround I'd rather using the nice API in tc-go to build the image from a Dockerfile (which I double checked it works with TCCloud!)
