### PR TITLE
chore: print log line each time is produced

### DIFF
--- a/kong_test.go
+++ b/kong_test.go
@@ -27,7 +27,9 @@ func (g *TestLogConsumer) Accept(l testcontainers.Log) {
 		return
 	}
 
-	g.Msgs = append(g.Msgs, string(l.Content))
+	logLine := string(l.Content)
+	g.Msgs = append(g.Msgs, logLine)
+	fmt.Print(logLine)
 }
 
 func TestKongAdminAPI_ReturnVersion(t *testing.T) {
@@ -65,6 +67,7 @@ func TestKongAdminAPI_ReturnVersion(t *testing.T) {
 	err = kong.StartLogProducer(ctx)
 	assert.Nil(t, err)
 
+	defer kong.StopLogProducer()
 	kong.FollowOutput(&consumer)
 
 	// Clean up the container after the test is complete


### PR DESCRIPTION
## What does this PR do?
It prints each log line at the moment it's produced. For that, we are using fmt.Print method in the Accept implementation of the TestLogConsumer struct, defined in this test.

## Why is it important?
See the logs next to the test execution

## Sample test execution including logs
```
➜  testcontainers-go-kong git:(logconsumer) go test -v ./... -count 1
=== RUN   TestKongAdminAPI_ReturnVersion
2022/09/05 08:36:24 Starting container id: 53a788e48e7f image: docker.io/testcontainers/ryuk:0.3.3
2022/09/05 08:36:24 Waiting for container id 53a788e48e7f image: docker.io/testcontainers/ryuk:0.3.3
2022/09/05 08:36:24 Container is ready id: 53a788e48e7f image: docker.io/testcontainers/ryuk:0.3.3
Step 1/3 : ARG TC_KONG_IMAGE
Step 2/3 : FROM ${TC_KONG_IMAGE:-kong:2.8.1}
 ---> bf394ffed022
Step 3/3 : RUN mkdir -p /usr/local/kong/go-plugins/bin
 ---> Running in 996d2d33d523
Removing intermediate container 996d2d33d523
 ---> 2c83f847c3b7
Successfully built 2c83f847c3b7
Successfully tagged e22f5842-964a-4147-821f-f9a7d66b374a:52d4fdf5-f838-4c0d-877e-5949d2dcbb07
2022/09/05 08:36:26 Starting container id: e5165db0ca76 image: e22f5842-964a-4147-821f-f9a7d66b374a:52d4fdf5-f838-4c0d-877e-5949d2dcbb07
2022/09/05 08:36:26 Waiting for container id e5165db0ca76 image: e22f5842-964a-4147-821f-f9a7d66b374a:52d4fdf5-f838-4c0d-877e-5949d2dcbb07
2022/09/05 08:36:27 Container is ready id: e5165db0ca76 image: e22f5842-964a-4147-821f-f9a7d66b374a:52d4fdf5-f838-4c0d-877e-5949d2dcbb07
nginx: [warn] the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /usr/local/kong/nginx.conf:6
2022/09/05 06:36:27 [debug] 1168#0: [lua] globalpatches.lua:10: installing the globalpatches
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:460: init(): [dns-client] (re)configuring dns client
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:465: init(): [dns-client] staleTtl = 4
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:469: init(): [dns-client] noSynchronisation = nil
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:488: init(): [dns-client] query order = LAST, SRV, A, AAAA, CNAME
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-loopback = [::1]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:528: init(): [dns-client] adding A-record from 'hosts' file: e5165db0ca76 = 172.17.0.3
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localnet = [fe00::0]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allrouters = [ff02::2]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allnodes = [ff02::1]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localhost = [::1]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-mcastprefix = [ff00::0]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:528: init(): [dns-client] adding A-record from 'hosts' file: localhost = 127.0.0.1
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: localhost = [::1]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:552: init(): [dns-client] validTtl = nil
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:593: init(): [dns-client] nameserver 1.1.1.1
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:593: init(): [dns-client] nameserver 8.8.8.8
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:593: init(): [dns-client] nameserver 9.9.9.9
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:598: init(): [dns-client] attempts = 5
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:605: init(): [dns-client] no_random = true
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:614: init(): [dns-client] timeout = 2000 ms
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:618: init(): [dns-client] ndots = 1
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:620: init(): [dns-client] search = .
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:633: init(): [dns-client] badTtl = 1 s
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:635: init(): [dns-client] emptyTtl = 30 s
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:460: init(): [dns-client] (re)configuring dns client
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:465: init(): [dns-client] staleTtl = 4
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:469: init(): [dns-client] noSynchronisation = false
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:488: init(): [dns-client] query order = LAST, SRV, A, CNAME
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-loopback = [::1]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:528: init(): [dns-client] adding A-record from 'hosts' file: e5165db0ca76 = 172.17.0.3
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localnet = [fe00::0]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allrouters = [ff02::2]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allnodes = [ff02::1]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localhost = [::1]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-mcastprefix = [ff00::0]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:528: init(): [dns-client] adding A-record from 'hosts' file: localhost = 127.0.0.1
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: localhost = [::1]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:552: init(): [dns-client] validTtl = nil
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:593: init(): [dns-client] nameserver 1.1.1.1
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:593: init(): [dns-client] nameserver 8.8.8.8
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:593: init(): [dns-client] nameserver 9.9.9.9
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:598: init(): [dns-client] attempts = 5
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:605: init(): [dns-client] no_random = true
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:614: init(): [dns-client] timeout = 2000 ms
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:618: init(): [dns-client] ndots = 1
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:620: init(): [dns-client] search = .
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:633: init(): [dns-client] badTtl = 1 s
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:635: init(): [dns-client] emptyTtl = 30 s
2022/09/05 06:36:27 [debug] 1168#0: [lua] globalpatches.lua:270: randomseed(): seeding PRNG from OpenSSL RAND_bytes()
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:460: init(): [dns-client] (re)configuring dns client
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:465: init(): [dns-client] staleTtl = 4
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:469: init(): [dns-client] noSynchronisation = false
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:488: init(): [dns-client] query order = LAST, SRV, A, CNAME
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-loopback = [::1]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:528: init(): [dns-client] adding A-record from 'hosts' file: e5165db0ca76 = 172.17.0.3
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localnet = [fe00::0]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allrouters = [ff02::2]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allnodes = [ff02::1]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localhost = [::1]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-mcastprefix = [ff00::0]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:528: init(): [dns-client] adding A-record from 'hosts' file: localhost = 127.0.0.1
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: localhost = [::1]
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:552: init(): [dns-client] validTtl = nil
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:593: init(): [dns-client] nameserver 1.1.1.1
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:593: init(): [dns-client] nameserver 8.8.8.8
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:593: init(): [dns-client] nameserver 9.9.9.9
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:598: init(): [dns-client] attempts = 5
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:605: init(): [dns-client] no_random = true
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:614: init(): [dns-client] timeout = 2000 ms
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:618: init(): [dns-client] ndots = 1
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:620: init(): [dns-client] search = .
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:633: init(): [dns-client] badTtl = 1 s
2022/09/05 06:36:27 [debug] 1168#0: [lua] client.lua:635: init(): [dns-client] emptyTtl = 30 s
2022/09/05 06:36:27 [debug] 1168#0: [kong] process.lua:62 search config for pluginserver named: goplug
2022/09/05 06:36:27 [debug] 1168#0: [lua] plugins.lua:245: load_plugin(): Loading plugin: goplug
2022/09/05 06:36:27 [notice] 1168#0: using the "epoll" event method
2022/09/05 06:36:27 [notice] 1168#0: openresty/1.19.9.1
2022/09/05 06:36:27 [notice] 1168#0: built by gcc 6.4.0 (Alpine 6.4.0) 
2022/09/05 06:36:27 [notice] 1168#0: OS: Linux 5.15.0-41-generic
2022/09/05 06:36:27 [notice] 1168#0: getrlimit(RLIMIT_NOFILE): 1048576:1048576
2022/09/05 06:36:27 [notice] 1168#0: start worker processes
2022/09/05 06:36:27 [notice] 1168#0: start worker process 1195
2022/09/05 06:36:27 [notice] 1168#0: start worker process 1199
2022/09/05 06:36:27 [notice] 1168#0: start worker process 1200
2022/09/05 06:36:27 [notice] 1168#0: start worker process 1202
2022/09/05 06:36:27 [notice] 1168#0: signal 17 (SIGCHLD) received from 1174
2022/09/05 06:36:27 [debug] 1195#0: *1 [lua] globalpatches.lua:270: randomseed(): seeding PRNG from OpenSSL RAND_bytes()
2022/09/05 06:36:27 [debug] 1199#0: *2 [lua] globalpatches.lua:270: randomseed(): seeding PRNG from OpenSSL RAND_bytes()
2022/09/05 06:36:27 [debug] 1195#0: *1 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=resty-worker-events, event=started, pid=1195, data=nil
2022/09/05 06:36:27 [debug] 1199#0: *2 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=resty-worker-events, event=started, pid=1199, data=nil
2022/09/05 06:36:27 [debug] 1200#0: *3 [lua] globalpatches.lua:270: randomseed(): seeding PRNG from OpenSSL RAND_bytes()
2022/09/05 06:36:27 [debug] 1202#0: *4 [lua] globalpatches.lua:270: randomseed(): seeding PRNG from OpenSSL RAND_bytes()
2022/09/05 06:36:27 [debug] 1200#0: *3 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=resty-worker-events, event=started, pid=1200, data=nil
2022/09/05 06:36:27 [debug] 1202#0: *4 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=resty-worker-events, event=started, pid=1202, data=nil
2022/09/05 06:36:27 [notice] 1199#0: *2 [lua] init.lua:260: purge(): [DB cache] purging (local) cache, context: init_worker_by_lua*
2022/09/05 06:36:27 [debug] 1199#0: *2 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=resty-worker-events, event=started, pid=1200, data=nil
2022/09/05 06:36:27 [debug] 1199#0: *2 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=resty-worker-events, event=started, pid=1202, data=nil
2022/09/05 06:36:27 [debug] 1199#0: *2 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=mlcache, event=mlcache:purge:kong_core_db_cache, pid=1199, data=
2022/09/05 06:36:27 [notice] 1199#0: *2 [lua] init.lua:260: purge(): [DB cache] purging (local) cache, context: init_worker_by_lua*
2022/09/05 06:36:27 [debug] 1199#0: *2 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=mlcache, event=mlcache:purge:kong_db_cache, pid=1199, data=
2022/09/05 06:36:27 [notice] 1199#0: *2 [kong] init.lua:426 declarative config loaded from /usr/local/kong/kong.yaml, context: init_worker_by_lua*
2022/09/05 06:36:27 [debug] 1199#0: *2 [lua] counter.lua:70: new(): start timer for shdict kong on worker 1
2022/09/05 06:36:27 [notice] 1199#0: *2 [kong] init.lua:312 only worker #0 can manage, context: init_worker_by_lua*
2022/09/05 06:36:27 [notice] 1195#0: *1 [lua] globalpatches.lua:62: sleep(): executing a blocking 'sleep' (0.001 seconds), context: init_worker_by_lua*
2022/09/05 06:36:27 [debug] 1200#0: *3 [lua] counter.lua:70: new(): start timer for shdict kong on worker 2
2022/09/05 06:36:27 [notice] 1200#0: *3 [kong] init.lua:312 only worker #0 can manage, context: init_worker_by_lua*
2022/09/05 06:36:27 [debug] 1195#0: *1 [lua] counter.lua:70: new(): start timer for shdict kong on worker 0
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:460: init(): [dns-client] (re)configuring dns client
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:465: init(): [dns-client] staleTtl = 4
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:469: init(): [dns-client] noSynchronisation = false
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:488: init(): [dns-client] query order = LAST, SRV, A, CNAME
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-loopback = [::1]
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:528: init(): [dns-client] adding A-record from 'hosts' file: e5165db0ca76 = 172.17.0.3
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localnet = [fe00::0]
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allrouters = [ff02::2]
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allnodes = [ff02::1]
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localhost = [::1]
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-mcastprefix = [ff00::0]
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:528: init(): [dns-client] adding A-record from 'hosts' file: localhost = 127.0.0.1
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: localhost = [::1]
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:552: init(): [dns-client] validTtl = nil
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:593: init(): [dns-client] nameserver 1.1.1.1
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:593: init(): [dns-client] nameserver 8.8.8.8
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:593: init(): [dns-client] nameserver 9.9.9.9
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:598: init(): [dns-client] attempts = 5
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:605: init(): [dns-client] no_random = true
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:614: init(): [dns-client] timeout = 2000 ms
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:618: init(): [dns-client] ndots = 1
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:620: init(): [dns-client] search = .
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:633: init(): [dns-client] badTtl = 1 s
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] client.lua:635: init(): [dns-client] emptyTtl = 30 s
2022/09/05 06:36:27 [debug] 1202#0: *4 [lua] counter.lua:70: new(): start timer for shdict kong on worker 3
2022/09/05 06:36:27 [notice] 1202#0: *4 [kong] init.lua:312 only worker #0 can manage, context: init_worker_by_lua*
2022/09/05 06:36:27 [debug] 1199#0: *5 [lua] balancers.lua:263: create_balancers(): initialized 0 balancer(s), 0 error(s)
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:460: init(): [dns-client] (re)configuring dns client
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:465: init(): [dns-client] staleTtl = 4
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:469: init(): [dns-client] noSynchronisation = false
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:460: init(): [dns-client] (re)configuring dns client
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:465: init(): [dns-client] staleTtl = 4
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:469: init(): [dns-client] noSynchronisation = false
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:488: init(): [dns-client] query order = LAST, SRV, A, CNAME
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-loopback = [::1]
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:528: init(): [dns-client] adding A-record from 'hosts' file: e5165db0ca76 = 172.17.0.3
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localnet = [fe00::0]
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allrouters = [ff02::2]
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allnodes = [ff02::1]
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localhost = [::1]
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-mcastprefix = [ff00::0]
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:528: init(): [dns-client] adding A-record from 'hosts' file: localhost = 127.0.0.1
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: localhost = [::1]
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:552: init(): [dns-client] validTtl = nil
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:488: init(): [dns-client] query order = LAST, SRV, A, CNAME
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-loopback = [::1]
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:528: init(): [dns-client] adding A-record from 'hosts' file: e5165db0ca76 = 172.17.0.3
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localnet = [fe00::0]
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allrouters = [ff02::2]
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allnodes = [ff02::1]
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:593: init(): [dns-client] nameserver 1.1.1.1
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:593: init(): [dns-client] nameserver 8.8.8.8
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:593: init(): [dns-client] nameserver 9.9.9.9
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localhost = [::1]
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:598: init(): [dns-client] attempts = 5
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:605: init(): [dns-client] no_random = true
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:614: init(): [dns-client] timeout = 2000 ms
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:618: init(): [dns-client] ndots = 1
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:620: init(): [dns-client] search = .
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:633: init(): [dns-client] badTtl = 1 s
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] client.lua:635: init(): [dns-client] emptyTtl = 30 s
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-mcastprefix = [ff00::0]
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:528: init(): [dns-client] adding A-record from 'hosts' file: localhost = 127.0.0.1
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: localhost = [::1]
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:552: init(): [dns-client] validTtl = nil
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:593: init(): [dns-client] nameserver 1.1.1.1
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:593: init(): [dns-client] nameserver 8.8.8.8
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:593: init(): [dns-client] nameserver 9.9.9.9
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:598: init(): [dns-client] attempts = 5
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:605: init(): [dns-client] no_random = true
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:614: init(): [dns-client] timeout = 2000 ms
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:618: init(): [dns-client] ndots = 1
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:620: init(): [dns-client] search = .
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:633: init(): [dns-client] badTtl = 1 s
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] client.lua:635: init(): [dns-client] emptyTtl = 30 s
2022/09/05 06:36:27 [debug] 1195#0: *7 [lua] balancers.lua:263: create_balancers(): initialized 0 balancer(s), 0 error(s)
2022/09/05 06:36:27 [notice] 1195#0: *8 [kong] process.lua:256 Starting goplug, context: ngx.timer
2022/09/05 06:36:27 [debug] 1200#0: *6 [lua] balancers.lua:263: create_balancers(): initialized 0 balancer(s), 0 error(s)
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:460: init(): [dns-client] (re)configuring dns client
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:465: init(): [dns-client] staleTtl = 4
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:469: init(): [dns-client] noSynchronisation = false
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:488: init(): [dns-client] query order = LAST, SRV, A, CNAME
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-loopback = [::1]
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:528: init(): [dns-client] adding A-record from 'hosts' file: e5165db0ca76 = 172.17.0.3
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localnet = [fe00::0]
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allrouters = [ff02::2]
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-allnodes = [ff02::1]
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-localhost = [::1]
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: ip6-mcastprefix = [ff00::0]
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:528: init(): [dns-client] adding A-record from 'hosts' file: localhost = 127.0.0.1
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:543: init(): [dns-client] adding AAAA-record from 'hosts' file: localhost = [::1]
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:552: init(): [dns-client] validTtl = nil
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:593: init(): [dns-client] nameserver 1.1.1.1
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:593: init(): [dns-client] nameserver 8.8.8.8
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:593: init(): [dns-client] nameserver 9.9.9.9
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:598: init(): [dns-client] attempts = 5
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:605: init(): [dns-client] no_random = true
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:614: init(): [dns-client] timeout = 2000 ms
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:618: init(): [dns-client] ndots = 1
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:620: init(): [dns-client] search = .
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:633: init(): [dns-client] badTtl = 1 s
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] client.lua:635: init(): [dns-client] emptyTtl = 30 s
2022/09/05 06:36:27 [debug] 1202#0: *9 [lua] balancers.lua:263: create_balancers(): initialized 0 balancer(s), 0 error(s)
2022/09/05 06:36:27 [info] 1195#0: *8 [goplug:1207] 2022/09/05 06:36:27 Listening on socket: /usr/local/kong/goplug.socket, context: ngx.timer
2022/09/05 06:36:27 [debug] 1195#0: *10 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=resty-worker-events, event=started, pid=1199, data=nil
2022/09/05 06:36:27 [debug] 1195#0: *10 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=resty-worker-events, event=started, pid=1200, data=nil
2022/09/05 06:36:27 [debug] 1195#0: *10 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=resty-worker-events, event=started, pid=1202, data=nil
2022/09/05 06:36:27 [debug] 1195#0: *10 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=mlcache, event=mlcache:purge:kong_core_db_cache, pid=1199, data=
2022/09/05 06:36:27 [debug] 1195#0: *10 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=mlcache, event=mlcache:purge:kong_db_cache, pid=1199, data=
2022/09/05 06:36:27 [debug] 1195#0: *10 [lua] init.lua:27: Loading Admin API endpoints
2022/09/05 06:36:27 [debug] 1195#0: *10 [lua] init.lua:118: No API endpoints loaded for plugin: goplug
172.17.0.1 - - [05/Sep/2022:06:36:27 +0000] "GET / HTTP/1.1" 200 9619 "-" "Go-http-client/1.1"
2022/09/05 06:36:27 [info] 1195#0: *8 [goplug:1207] 2022/09/05 06:36:27 Got request from Go-http-client/1.1, context: ngx.timer
2022/09/05 06:36:28 [debug] 1195#0: *11 [lua] init.lua:1006: balancer(): setting address (try 1): 172.67.134.112:80
2022/09/05 06:36:28 [debug] 1195#0: *11 [lua] init.lua:1035: balancer(): enabled connection keepalive (pool=172.67.134.112|80, pool_size=60, idle_timeout=60, max_requests=100)
172.17.0.1 - - [05/Sep/2022:06:36:28 +0000] "GET / HTTP/1.1" 200 547 "-" "Go-http-client/1.1"
--- PASS: TestKongAdminAPI_ReturnVersion (4.60s)
PASS
ok      github.com/gamussa/testcontainers-go-kong       4.773s
?       github.com/gamussa/testcontainers-go-kong/go-plugins    [no test files]
```